### PR TITLE
fix evaluation days

### DIFF
--- a/apps/wpf_baseline_gru/evaluation.py
+++ b/apps/wpf_baseline_gru/evaluation.py
@@ -73,7 +73,7 @@ def evaluate(settings):
     day_len = settings["day_len"]
     day_acc = []
     for idx in range(0, preds.shape[0]):
-        acc = 1 - metrics.rmse(preds[idx, -day_len:, -1], gts[idx, -day_len:, -1]) / (settings["capacity"] * 1000)
+        acc = 1 - metrics.rmse(preds[idx, -day_len*2:, -1], gts[idx, -day_len*2:, -1]) / (settings["capacity"] * 1000)
         if acc != acc:
             continue
         day_acc.append(acc)


### PR DESCRIPTION
> https://aistudio.baidu.com/aistudio/competition/detail/152/0/datasets
> We will evaluate the model by 48 hours ahead prediction (instead of the previous 42 hours ahead prediction) to simplify the evaluation setting and to avoid confusion.

So here it should be 2 days?